### PR TITLE
emyg atod fix __int128 version of DiyFp_multiply

### DIFF
--- a/src/emyg/emyg_dtoa.c
+++ b/src/emyg/emyg_dtoa.c
@@ -97,13 +97,13 @@ static inline DiyFp DiyFp_multiply (const DiyFp lhs, const DiyFp rhs) {
 	if (l & (uint64_t(1) << 63)) // rounding
 		h++;
 	return DiyFp_fro_parts(h, e + rhs.e + 64);
-#elif (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) && defined(__x86_64__)
+#elif ((__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || __clang_major__ >= 9) && defined(__x86_64__))
 	unsigned __int128 p = (unsigned __int128 )(lhs.f) * (unsigned __int128 )(rhs.f);
 	uint64_t h = p >> 64;
 	uint64_t l = (uint64_t )(p);
-	if (l & (uint64_t(1) << 63)) // rounding
+	if (l & ((uint64_t )1u << 63)) // rounding
 		h++;
-	return DiyFp_from_parts(h, e + rhs.e + 64);
+	return DiyFp_from_parts(h, lhs.e + rhs.e + 64);
 #else
 	const uint64_t M32 = 0xFFFFFFFF;
 	const uint64_t a = lhs.f >> 32;


### PR DESCRIPTION
This is a fix for issue #10 