### PR TITLE
Fix building failure due to floaxie test dependency on C++14 standard

### DIFF
--- a/src/floaxietest.cpp
+++ b/src/floaxietest.cpp
@@ -1,3 +1,5 @@
+#if __cplusplus >= 201402L
+
 #include "test.h"
 #include "floaxie/ftoa.h"
 
@@ -7,3 +9,5 @@ void dtoa_floaxie(double v, char* buffer)
 }
 
 REGISTER_TEST(floaxie);
+
+#endif


### PR DESCRIPTION
As @vitaut pointed in #13, building the `floaxie` test proposed by me some time ago fails when pre-C++14 standard is used by the compiler. This little fix just let `floaxie` be skipped from the test suite in this case.

Sorry for the error made, and I hope this fix would help the problem.