### PR TITLE
Add terminating nul in double-conversion benchmark

### DIFF
--- a/src/doubleconvtest.cpp
+++ b/src/doubleconvtest.cpp
@@ -6,6 +6,7 @@ using namespace double_conversion;
 void dtoa_doubleconv(double value, char* buffer) {
 	StringBuilder sb(buffer, 26);
 	DoubleToStringConverter::EcmaScriptConverter().ToShortest(value, &sb);
+	sb.Finalize();
 }
 
 REGISTER_TEST(doubleconv);


### PR DESCRIPTION
This PR adds a terminating NUL to the output buffer in the double-conversion benchmark for consistency with other benchmarks.